### PR TITLE
Implement new semantic search UI

### DIFF
--- a/components/AISummary.tsx
+++ b/components/AISummary.tsx
@@ -1,0 +1,93 @@
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { AlertTriangle, Bot, Info } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+
+interface AISummaryProps {
+  searchQuery: string;
+  summary: string;
+  loading: boolean;
+}
+
+export function AISummary({ searchQuery, summary, loading }: AISummaryProps) {
+  // Show default explanation if no search query
+  if (!searchQuery.trim()) {
+    return (
+      <Card className="p-6 mb-6 bg-gradient-to-r from-primary-50 to-accent-50 border border-primary-200">
+        <div className="flex items-center space-x-2 mb-4">
+          <Info className="w-5 h-5 text-primary-600" />
+          <h3 className="text-lg font-semibold text-gray-900">How Metrix Works</h3>
+          <Badge variant="outline" className="bg-primary-100 text-primary-700 border-primary-300">
+            AI Powered
+          </Badge>
+        </div>
+
+        <div className="prose prose-sm max-w-none mb-4">
+          <p className="text-gray-700 leading-relaxed">
+            Metrix combines the power of AI with comprehensive clinical guideline databases to provide you with both
+            <strong> natural language explanations</strong> and <strong>indexed clinical results</strong>. When you search
+            for a clinical topic, you'll receive an AI-generated summary of the key management principles followed by
+            relevant guidelines from trusted sources like AHA/ACC, WHO, NICE, and leading medical institutions.
+            This dual approach ensures greater speed and accuracy in accessing critical clinical information.
+          </p>
+        </div>
+
+        <Alert className="bg-blue-50 border-blue-200">
+          <Info className="h-4 w-4 text-blue-600" />
+          <AlertDescription className="text-blue-800 text-sm">
+            <strong>Getting Started:</strong> Try searching for conditions like "sepsis", "myocardial infarction",
+            or "cellulitis" to see how Metrix provides comprehensive clinical guidance.
+          </AlertDescription>
+        </Alert>
+      </Card>
+    );
+  }
+
+  if (loading) {
+    return (
+      <Card className="p-6 mb-6 bg-gradient-to-r from-primary-50 to-accent-50 border border-primary-200">
+        <div className="animate-pulse">
+          <div className="flex items-center space-x-2 mb-4">
+            <div className="w-5 h-5 bg-gray-300 rounded"></div>
+            <div className="h-4 bg-gray-300 rounded w-32"></div>
+          </div>
+          <div className="space-y-2">
+            <div className="h-4 bg-gray-300 rounded w-full"></div>
+            <div className="h-4 bg-gray-300 rounded w-3/4"></div>
+            <div className="h-4 bg-gray-300 rounded w-1/2"></div>
+          </div>
+        </div>
+      </Card>
+    );
+  }
+
+  if (!summary) {
+    return null;
+  }
+
+  return (
+    <div className="mb-6">
+      <Card className="p-6 bg-gradient-to-r from-primary-50 to-accent-50 border border-primary-200">
+        <div className="flex items-center space-x-2 mb-4">
+          <Bot className="w-5 h-5 text-primary-600" />
+          <h3 className="text-lg font-semibold text-gray-900">AI Summary: Clinical Guidelines for "{searchQuery}"</h3>
+          <Badge variant="outline" className="bg-primary-100 text-primary-700 border-primary-300">
+            AI Generated
+          </Badge>
+        </div>
+
+        <div className="prose prose-sm max-w-none mb-4">
+          <p className="text-gray-700 leading-relaxed">{summary}</p>
+        </div>
+
+        <Alert className="bg-yellow-50 border-yellow-200">
+          <AlertTriangle className="h-4 w-4 text-yellow-600" />
+          <AlertDescription className="text-yellow-800 text-sm">
+            <strong>Important Disclaimer:</strong> This AI-generated summary is for informational purposes only and may contain errors.
+            Always verify information against the original guidelines below and consult with qualified healthcare professionals for clinical decisions.
+          </AlertDescription>
+        </Alert>
+      </Card>
+    </div>
+  );
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,21 +1,61 @@
-import Link from 'next/link';
+import { User, Shield } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useState } from 'react';
+import { ProfileModal } from './ProfileModal';
+import { PrivacyPolicyModal } from './PrivacyPolicyModal';
 
-export default function Header() {
+export function Header() {
+  const [isProfileOpen, setIsProfileOpen] = useState(false);
+  const [isPrivacyOpen, setIsPrivacyOpen] = useState(false);
+
   return (
-    <header className="bg-white border-b border-gray-200">
-      <div className="max-w-6xl mx-auto flex items-center justify-between p-4">
-        <Link href="/" className="font-semibold text-teal-700">
-          Metrix AI
-        </Link>
-        <nav className="space-x-4 text-sm">
-          <Link href="/" className="text-gray-600 hover:text-teal-700">
-            Policy Search
-          </Link>
-          <Link href="/clinical-scoring-tools" className="text-gray-600 hover:text-teal-700">
-            Risk &amp; Scoring Tools
-          </Link>
-        </nav>
-      </div>
-    </header>
+    <>
+      <header className="bg-white border-b border-gray-200 shadow-sm">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between h-16">
+            {/* Logo */}
+            <div className="flex items-center space-x-4">
+              <div className="flex items-center space-x-2">
+                <div className="w-8 h-8 bg-gradient-to-br from-primary-500 to-primary-600 rounded-lg flex items-center justify-center">
+                  <Shield className="w-5 h-5 text-white" />
+                </div>
+                <div>
+                  <h1 className="text-xl font-bold text-gray-900">Metrix</h1>
+                  <p className="text-xs text-gray-500">Clinical Guidelines Platform</p>
+                </div>
+              </div>
+            </div>
+
+            {/* Actions */}
+            <div className="flex items-center space-x-3">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setIsProfileOpen(true)}
+                className="text-gray-700 hover:bg-gray-100"
+              >
+                <User className="w-4 h-4 mr-2" />
+                Profile
+              </Button>
+
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setIsPrivacyOpen(true)}
+                className="text-xs text-gray-500 hover:text-gray-700"
+              >
+                Privacy Policy
+              </Button>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <ProfileModal isOpen={isProfileOpen} onClose={() => setIsProfileOpen(false)} />
+
+      <PrivacyPolicyModal isOpen={isPrivacyOpen} onClose={() => setIsPrivacyOpen(false)} />
+    </>
   );
 }
+
+export default Header;

--- a/components/PopularSearches.tsx
+++ b/components/PopularSearches.tsx
@@ -1,0 +1,58 @@
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { TrendingUp } from 'lucide-react';
+
+interface PopularSearchesProps {
+  onSearchSelect: (query: string) => void;
+}
+
+export function PopularSearches({ onSearchSelect }: PopularSearchesProps) {
+  const popularSearches = [
+    {
+      title: 'Acute Myocardial Infarction Management',
+      description:
+        'Evidence-based guidelines for STEMI and NSTEMI diagnosis, treatment, and post-MI care including antiplatelet therapy and reperfusion strategies.',
+      searchQuery: 'myocardial infarction',
+    },
+    {
+      title: 'Sepsis Recognition and Management',
+      description:
+        'Early identification protocols, sepsis bundles, antibiotic selection, and organ support strategies for septic patients.',
+      searchQuery: 'sepsis management',
+    },
+    {
+      title: 'Cellulitis Treatment Guidelines',
+      description:
+        'Antibiotic selection, severity assessment, and management approaches for skin and soft tissue infections.',
+      searchQuery: 'cellulitis',
+    },
+  ];
+
+  return (
+    <div className="max-w-4xl mx-auto mb-8">
+      <div className="mb-6 text-center">
+        <div className="flex items-center justify-center space-x-2 mb-2">
+          <TrendingUp className="w-5 h-5 text-primary-600" />
+          <h2 className="text-xl font-semibold text-gray-900">Popular Searches</h2>
+        </div>
+        <p className="text-gray-600">Get started with these commonly searched clinical guidelines</p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        {popularSearches.map((search, index) => (
+          <Card key={index} className="p-4 hover:shadow-md transition-shadow duration-200 border border-gray-200">
+            <h3 className="font-semibold text-gray-900 mb-2">{search.title}</h3>
+            <p className="text-sm text-gray-600 mb-4 line-clamp-3">{search.description}</p>
+            <Button
+              size="sm"
+              onClick={() => onSearchSelect(search.searchQuery)}
+              className="w-full bg-primary hover:bg-primary-600"
+            >
+              Search Guidelines
+            </Button>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/PrivacyPolicyModal.tsx
+++ b/components/PrivacyPolicyModal.tsx
@@ -1,0 +1,25 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogClose } from '@/components/ui/Dialog';
+import { Button } from '@/components/ui/button';
+
+interface PrivacyPolicyModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function PrivacyPolicyModal({ isOpen, onClose }: PrivacyPolicyModalProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="bg-white rounded-lg">
+        <DialogHeader>
+          <DialogTitle>Privacy Policy</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-gray-700 mb-4">The privacy policy content would be displayed here.</p>
+        <DialogFooter>
+          <DialogClose>
+            <Button size="sm" onClick={onClose}>Close</Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -1,0 +1,25 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogClose } from '@/components/ui/Dialog';
+import { Button } from '@/components/ui/button';
+
+interface ProfileModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function ProfileModal({ isOpen, onClose }: ProfileModalProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="bg-white rounded-lg">
+        <DialogHeader>
+          <DialogTitle>User Profile</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-gray-700 mb-4">Profile information goes here.</p>
+        <DialogFooter>
+          <DialogClose>
+            <Button size="sm" onClick={onClose}>Close</Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/SearchFilters.tsx
+++ b/components/SearchFilters.tsx
@@ -1,0 +1,63 @@
+import { Card } from '@/components/ui/card';
+
+interface SearchFiltersProps {
+  isOpen: boolean;
+  searchMode: string;
+  filters: {
+    sources: string[];
+    specialties: string[];
+    dateRange: string;
+    evidenceLevel: string;
+  };
+  onFiltersChange: (filters: any) => void;
+}
+
+export function SearchFilters({ isOpen, filters, onFiltersChange }: SearchFiltersProps) {
+  if (!isOpen) return null;
+
+  const sources = ['AHA/ACC Guidelines', 'WHO Guidelines', 'NICE Guidelines'];
+  const specialties = ['Cardiology', 'Emergency Medicine'];
+
+  const toggle = (group: 'sources' | 'specialties', value: string) => {
+    const current = filters[group];
+    const next = current.includes(value)
+      ? current.filter((v) => v !== value)
+      : [...current, value];
+    onFiltersChange({ ...filters, [group]: next });
+  };
+
+  return (
+    <Card className="p-4 mt-4 space-y-4 border border-gray-200">
+      <div>
+        <p className="font-semibold mb-2">Sources</p>
+        <div className="space-y-1">
+          {sources.map((src) => (
+            <label key={src} className="flex items-center space-x-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={filters.sources.includes(src)}
+                onChange={() => toggle('sources', src)}
+              />
+              <span>{src}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+      <div>
+        <p className="font-semibold mb-2">Specialties</p>
+        <div className="space-y-1">
+          {specialties.map((spec) => (
+            <label key={spec} className="flex items-center space-x-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={filters.specialties.includes(spec)}
+                onChange={() => toggle('specialties', spec)}
+              />
+              <span>{spec}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/components/SearchResults.tsx
+++ b/components/SearchResults.tsx
@@ -1,0 +1,43 @@
+import { Card } from '@/components/ui/card';
+
+interface SearchResultsProps {
+  results: any[];
+  searchMode: string;
+  loading: boolean;
+}
+
+export function SearchResults({ results, loading }: SearchResultsProps) {
+  if (loading) {
+    return <p className="text-center text-gray-600">Loading results...</p>;
+  }
+
+  if (!results.length) {
+    return <p className="text-center text-gray-600">No results found.</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      {results.map((r, idx) => (
+        <Card key={idx} className="p-4 border border-gray-200">
+          <h3 className="font-semibold text-gray-900 mb-1">
+            {r.document_title || r.title}
+          </h3>
+          {r.heading && <p className="text-sm text-gray-600 mb-1">{r.heading}</p>}
+          {r.page_number && (
+            <p className="text-xs text-gray-500">Page {r.page_number}</p>
+          )}
+          {r.url && (
+            <a
+              href={r.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-primary-600 underline"
+            >
+              View Source
+            </a>
+          )}
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/components/SearchSection.tsx
+++ b/components/SearchSection.tsx
@@ -1,0 +1,72 @@
+import { Search, Filter } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card } from '@/components/ui/card';
+import { SearchFilters } from './SearchFilters';
+
+interface SearchSectionProps {
+  searchQuery: string;
+  onSearchChange: (query: string) => void;
+  showFilters: boolean;
+  onFilterToggle: () => void;
+  filters: {
+    sources: string[];
+    specialties: string[];
+    dateRange: string;
+    evidenceLevel: string;
+  };
+  onFiltersChange: (filters: any) => void;
+}
+
+export function SearchSection({
+  searchQuery,
+  onSearchChange,
+  showFilters,
+  onFilterToggle,
+  filters,
+  onFiltersChange,
+}: SearchSectionProps) {
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onSearchChange(e.target.value);
+  };
+
+  return (
+    <div className="w-full max-w-4xl mx-auto mb-8">
+      <Card className="p-8 bg-white shadow-lg border border-gray-200">
+        {/* Search Bar */}
+        <div className="mb-6">
+          <div className="relative">
+            <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
+            <Input
+              type="text"
+              placeholder="Search clinical guidelines..."
+              value={searchQuery}
+              onChange={handleSearchChange}
+              className="pl-12 pr-4 py-4 w-full text-lg border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            />
+          </div>
+        </div>
+
+        {/* Filter Toggle */}
+        <div className="flex justify-center">
+          <Button
+            variant="outline"
+            onClick={onFilterToggle}
+            className="border-gray-300 text-gray-700 hover:bg-gray-50"
+          >
+            <Filter className="w-4 h-4 mr-2" />
+            {showFilters ? 'Hide Filters' : 'Show Filters'}
+          </Button>
+        </div>
+      </Card>
+
+      {/* Filters */}
+      <SearchFilters
+        isOpen={showFilters}
+        searchMode="guidelines"
+        filters={filters}
+        onFiltersChange={onFiltersChange}
+      />
+    </div>
+  );
+}

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
+  className?: string;
+}
+
+export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={`rounded-md p-4 ${className ?? ''}`} {...props} />
+  ),
+);
+Alert.displayName = 'Alert';
+
+export interface AlertDescriptionProps
+  extends React.HTMLAttributes<HTMLParagraphElement> {
+  className?: string;
+}
+
+export const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  AlertDescriptionProps
+>(({ className, ...props }, ref) => (
+  <p ref={ref} className={className} {...props} />
+));
+AlertDescription.displayName = 'AlertDescription';

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,14 +4,12 @@ import { Inter } from 'next/font/google';
 import { appWithTranslation } from 'next-i18next';
 
 import '@/styles/globals.css';
-import Header from '@/components/Header';
 
 const inter = Inter({ subsets: ['latin'] });
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <div className={inter.className}>
-      <Header />
       <Component {...pageProps} />
     </div>
   );


### PR DESCRIPTION
## Summary
- refactor Header component with profile and privacy modals
- add semantic search page with filters and AI summary
- create UI pieces (AISummary, PopularSearches, SearchResults, SearchSection)
- implement basic filter and modal components
- remove global header from _app
- provide minimal alert component

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408c041ff083298c097392ca8c0a86