### PR TITLE
Fix import path casing for UI components

### DIFF
--- a/components/AISummary.tsx
+++ b/components/AISummary.tsx
@@ -1,5 +1,5 @@
-import { Card } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/Card';
+import { Badge } from '@/components/ui/Badge';
 import { AlertTriangle, Bot, Info } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 

--- a/components/PopularSearches.tsx
+++ b/components/PopularSearches.tsx
@@ -1,4 +1,4 @@
-import { Card } from '@/components/ui/card';
+import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/button';
 import { TrendingUp } from 'lucide-react';
 

--- a/components/SearchFilters.tsx
+++ b/components/SearchFilters.tsx
@@ -1,4 +1,4 @@
-import { Card } from '@/components/ui/card';
+import { Card } from '@/components/ui/Card';
 
 interface SearchFiltersProps {
   isOpen: boolean;

--- a/components/SearchResults.tsx
+++ b/components/SearchResults.tsx
@@ -1,4 +1,4 @@
-import { Card } from '@/components/ui/card';
+import { Card } from '@/components/ui/Card';
 
 interface SearchResultsProps {
   results: any[];

--- a/components/SearchSection.tsx
+++ b/components/SearchSection.tsx
@@ -1,7 +1,7 @@
 import { Search, Filter } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Card } from '@/components/ui/card';
+import { Card } from '@/components/ui/Card';
 import { SearchFilters } from './SearchFilters';
 
 interface SearchSectionProps {


### PR DESCRIPTION
## Summary
- correct case of Card and Badge imports across components

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive config)*

------
https://chatgpt.com/codex/tasks/task_e_68409152fffc8329b2bfe7c3e73dc2bf