### PR TITLE
Improve UI theme and modals

### DIFF
--- a/components/AISummary.tsx
+++ b/components/AISummary.tsx
@@ -13,11 +13,11 @@ export function AISummary({ searchQuery, summary, loading }: AISummaryProps) {
   // Show default explanation if no search query
   if (!searchQuery.trim()) {
     return (
-      <Card className="p-6 mb-6 bg-gradient-to-r from-primary-50 to-accent-50 border border-primary-200">
+      <Card className="p-6 mb-6 bg-gradient-to-r from-teal-50 to-cyan-50 border border-teal-200">
         <div className="flex items-center space-x-2 mb-4">
-          <Info className="w-5 h-5 text-primary-600" />
+          <Info className="w-5 h-5 text-teal-600" />
           <h3 className="text-lg font-semibold text-gray-900">How Metrix Works</h3>
-          <Badge variant="outline" className="bg-primary-100 text-primary-700 border-primary-300">
+          <Badge variant="outline" className="bg-teal-100 text-teal-700 border-teal-300">
             AI Powered
           </Badge>
         </div>
@@ -45,7 +45,7 @@ export function AISummary({ searchQuery, summary, loading }: AISummaryProps) {
 
   if (loading) {
     return (
-      <Card className="p-6 mb-6 bg-gradient-to-r from-primary-50 to-accent-50 border border-primary-200">
+      <Card className="p-6 mb-6 bg-gradient-to-r from-teal-50 to-cyan-50 border border-teal-200">
         <div className="animate-pulse">
           <div className="flex items-center space-x-2 mb-4">
             <div className="w-5 h-5 bg-gray-300 rounded"></div>
@@ -67,11 +67,11 @@ export function AISummary({ searchQuery, summary, loading }: AISummaryProps) {
 
   return (
     <div className="mb-6">
-      <Card className="p-6 bg-gradient-to-r from-primary-50 to-accent-50 border border-primary-200">
+      <Card className="p-6 bg-gradient-to-r from-teal-50 to-cyan-50 border border-teal-200">
         <div className="flex items-center space-x-2 mb-4">
-          <Bot className="w-5 h-5 text-primary-600" />
+          <Bot className="w-5 h-5 text-teal-600" />
           <h3 className="text-lg font-semibold text-gray-900">AI Summary: Clinical Guidelines for "{searchQuery}"</h3>
-          <Badge variant="outline" className="bg-primary-100 text-primary-700 border-primary-300">
+          <Badge variant="outline" className="bg-teal-100 text-teal-700 border-teal-300">
             AI Generated
           </Badge>
         </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -16,7 +16,7 @@ export function Header() {
             {/* Logo */}
             <div className="flex items-center space-x-4">
               <div className="flex items-center space-x-2">
-                <div className="w-8 h-8 bg-gradient-to-br from-primary-500 to-primary-600 rounded-lg flex items-center justify-center">
+                <div className="w-8 h-8 bg-gradient-to-br from-teal-500 to-teal-600 rounded-lg flex items-center justify-center">
                   <Shield className="w-5 h-5 text-white" />
                 </div>
                 <div>
@@ -32,7 +32,6 @@ export function Header() {
                 variant="ghost"
                 size="sm"
                 onClick={() => setIsProfileOpen(true)}
-                className="text-gray-700 hover:bg-gray-100"
               >
                 <User className="w-4 h-4 mr-2" />
                 Profile
@@ -42,7 +41,7 @@ export function Header() {
                 variant="ghost"
                 size="sm"
                 onClick={() => setIsPrivacyOpen(true)}
-                className="text-xs text-gray-500 hover:text-gray-700"
+                className="text-xs"
               >
                 Privacy Policy
               </Button>

--- a/components/PopularSearches.tsx
+++ b/components/PopularSearches.tsx
@@ -32,7 +32,7 @@ export function PopularSearches({ onSearchSelect }: PopularSearchesProps) {
     <div className="max-w-4xl mx-auto mb-8">
       <div className="mb-6 text-center">
         <div className="flex items-center justify-center space-x-2 mb-2">
-          <TrendingUp className="w-5 h-5 text-primary-600" />
+          <TrendingUp className="w-5 h-5 text-teal-600" />
           <h2 className="text-xl font-semibold text-gray-900">Popular Searches</h2>
         </div>
         <p className="text-gray-600">Get started with these commonly searched clinical guidelines</p>
@@ -46,7 +46,7 @@ export function PopularSearches({ onSearchSelect }: PopularSearchesProps) {
             <Button
               size="sm"
               onClick={() => onSearchSelect(search.searchQuery)}
-              className="w-full bg-primary hover:bg-primary-600"
+              className="w-full"
             >
               Search Guidelines
             </Button>

--- a/components/PrivacyPolicyModal.tsx
+++ b/components/PrivacyPolicyModal.tsx
@@ -1,4 +1,11 @@
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogClose } from '@/components/ui/Dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogClose,
+} from '@/components/ui/Dialog';
 import { Button } from '@/components/ui/button';
 
 interface PrivacyPolicyModalProps {
@@ -13,7 +20,21 @@ export function PrivacyPolicyModal({ isOpen, onClose }: PrivacyPolicyModalProps)
         <DialogHeader>
           <DialogTitle>Privacy Policy</DialogTitle>
         </DialogHeader>
-        <p className="text-sm text-gray-700 mb-4">The privacy policy content would be displayed here.</p>
+        <div className="text-sm text-gray-700 space-y-3 max-h-[60vh] overflow-y-auto mb-4">
+          <p>
+            We respect your privacy and are committed to protecting your personal information.
+            Any data you enter in this application is stored locally in your browser and
+            transmitted securely to our servers only when necessary to perform searches.
+          </p>
+          <p>
+            We do not share your personal details with third parties. Anonymous usage
+            statistics may be collected to help improve the quality of this service.
+          </p>
+          <p>
+            If you have any questions about how your data is handled, please contact us at
+            <a href="mailto:privacy@example.com" className="text-teal-600 underline">privacy@example.com</a>.
+          </p>
+        </div>
         <DialogFooter>
           <DialogClose>
             <Button size="sm" onClick={onClose}>Close</Button>

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -1,5 +1,14 @@
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogClose } from '@/components/ui/Dialog';
+import { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogClose,
+} from '@/components/ui/Dialog';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 
 interface ProfileModalProps {
   isOpen: boolean;
@@ -7,16 +16,42 @@ interface ProfileModalProps {
 }
 
 export function ProfileModal({ isOpen, onClose }: ProfileModalProps) {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+
+  useEffect(() => {
+    if (isOpen) {
+      setName(localStorage.getItem('userName') || '');
+      setEmail(localStorage.getItem('userEmail') || '');
+    }
+  }, [isOpen]);
+
+  const handleSave = () => {
+    localStorage.setItem('userName', name);
+    localStorage.setItem('userEmail', email);
+    onClose();
+  };
+
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="bg-white rounded-lg">
         <DialogHeader>
           <DialogTitle>User Profile</DialogTitle>
         </DialogHeader>
-        <p className="text-sm text-gray-700 mb-4">Profile information goes here.</p>
+        <div className="space-y-4 mb-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="name">Name</label>
+            <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="email">Email</label>
+            <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+          </div>
+        </div>
         <DialogFooter>
+          <Button size="sm" onClick={handleSave}>Save</Button>
           <DialogClose>
-            <Button size="sm" onClick={onClose}>Close</Button>
+            <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
           </DialogClose>
         </DialogFooter>
       </DialogContent>

--- a/components/SearchResults.tsx
+++ b/components/SearchResults.tsx
@@ -31,7 +31,7 @@ export function SearchResults({ results, loading }: SearchResultsProps) {
               href={r.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-sm text-primary-600 underline"
+              className="text-sm text-teal-600 underline"
             >
               View Source
             </a>

--- a/components/SearchSection.tsx
+++ b/components/SearchSection.tsx
@@ -42,7 +42,7 @@ export function SearchSection({
               placeholder="Search clinical guidelines..."
               value={searchQuery}
               onChange={handleSearchChange}
-              className="pl-12 pr-4 py-4 w-full text-lg border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              className="pl-12 pr-4 py-4 w-full text-lg border-gray-300 rounded-lg focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
             />
           </div>
         </div>
@@ -52,7 +52,6 @@ export function SearchSection({
           <Button
             variant="outline"
             onClick={onFilterToggle}
-            className="border-gray-300 text-gray-700 hover:bg-gray-50"
           >
             <Filter className="w-4 h-4 mr-2" />
             {showFilters ? 'Hide Filters' : 'Show Filters'}

--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -2,9 +2,9 @@
 import React from 'react';
 
 export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
-  /** 
-   * primary – blue background  
-   * secondary – subtle gray  
+  /**
+   * primary – teal background
+   * secondary – subtle gray
    * outline – border-only
    */
   variant?: 'primary' | 'secondary' | 'outline';
@@ -17,7 +17,7 @@ export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
       'inline-flex items-center rounded px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide';
 
     const variants: Record<NonNullable<BadgeProps['variant']>, string> = {
-      primary: 'bg-blue-500 text-white',
+      primary: 'bg-teal-600 text-white',
       secondary: 'bg-gray-200 text-gray-800',
       outline: 'border border-gray-300 text-gray-800',
     };

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -8,7 +8,7 @@ export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const Card = React.forwardRef<HTMLDivElement, CardProps>(
   ({ className, ...props }, ref) => {
-    const baseStyle = 'rounded-lg border bg-card text-card-foreground shadow-sm';
+    const baseStyle = 'rounded-lg border bg-white text-gray-900 shadow-sm';
     const combinedClassName = `${baseStyle} ${className ?? ''}`;
 
     return (

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -16,11 +16,11 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant = 'default', size = 'md', children, ...props }, ref) => {
 
     const baseStyles =
-      'inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-2';
+      'inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500';
     const variantStyles = {
-      default: 'bg-blue-600 hover:bg-blue-700 text-white border border-transparent',
-      outline: 'bg-transparent border border-gray-500 text-gray-100 hover:bg-gray-800',
-      ghost: 'bg-transparent text-gray-100 hover:bg-gray-800',
+      default: 'bg-teal-600 hover:bg-teal-700 text-white border border-transparent',
+      outline: 'bg-white border border-teal-600 text-teal-700 hover:bg-teal-50',
+      ghost: 'bg-transparent text-teal-700 hover:bg-teal-50',
     };
     const sizeStyles = {
       sm: 'px-3 py-1 text-sm',

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -10,9 +10,9 @@ export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {}
 export const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ className, ...props }, ref) => {
     const baseStyles =
-      'block w-full rounded-md border border-gray-700 bg-gray-900 text-gray-100 ' +
-      'placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500 ' +
-      'focus:border-transparent transition-colors duration-200';
+      'block w-full rounded-md border border-gray-300 bg-white text-gray-900 ' +
+      'placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-teal-500 ' +
+      'focus:border-teal-500 transition-colors';
 
     return (
       <input

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -29,7 +29,7 @@
 }
 
 html {
-  background: #202123;
+  background: #ffffff;
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
## Summary
- refine app theme with teal accents and white backgrounds
- update Privacy Policy modal with real copy
- make Profile modal editable and store data in localStorage
- adjust button, card and input components for new style
- tweak search section and other components to use teal colors

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409b31ae78832988c217cb72cb3e0c