### PR TITLE
Implement follow‑up search and modal tweaks

### DIFF
--- a/components/FollowUpSearchBar.tsx
+++ b/components/FollowUpSearchBar.tsx
@@ -1,0 +1,41 @@
+import { Search } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+interface FollowUpSearchBarProps {
+  query: string;
+  onQueryChange: (q: string) => void;
+  onSubmit: () => void;
+}
+
+export function FollowUpSearchBar({
+  query,
+  onQueryChange,
+  onSubmit,
+}: FollowUpSearchBarProps) {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      onSubmit();
+    }
+  };
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 p-4 z-50">
+      <div className="flex items-center max-w-3xl mx-auto">
+        <Input
+          type="text"
+          placeholder="Ask a follow-up question..."
+          value={query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          className="flex-grow mr-2"
+        />
+        <Button onClick={onSubmit} className="flex items-center">
+          <Search className="w-4 h-4 mr-2" />
+          Search
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/PrivacyPolicyModal.tsx
+++ b/components/PrivacyPolicyModal.tsx
@@ -20,7 +20,7 @@ export function PrivacyPolicyModal({
 }: PrivacyPolicyModalProps) {
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-4xl max-h-[80vh]">
+      <DialogContent className="max-w-4xl max-h-[80vh] bg-white">
         <DialogHeader>
           <DialogTitle className="flex items-center space-x-2">
             <Shield className="w-5 h-5 text-primary" />

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -42,7 +42,7 @@ export function ProfileModal({ isOpen, onClose }: ProfileModalProps) {
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="max-w-2xl bg-white">
         <DialogHeader>
           <DialogTitle className="flex items-center space-x-2">
             <User className="w-5 h-5 text-primary" />

--- a/pages/semantic-search.tsx
+++ b/pages/semantic-search.tsx
@@ -6,6 +6,7 @@ import { SearchSection } from '@/components/SearchSection';
 import { SearchResults } from '@/components/SearchResults';
 import { AISummary } from '@/components/AISummary';
 import { PopularSearches } from '@/components/PopularSearches';
+import { FollowUpSearchBar } from '@/components/FollowUpSearchBar';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:8000';
 
@@ -22,6 +23,7 @@ const SemanticSearch = () => {
   });
   const [results, setResults] = useState<any[]>([]);
   const [summary, setSummary] = useState('');
+  const [followUpQuery, setFollowUpQuery] = useState('');
 
   const fetchResults = async (query: string) => {
     setLoading(true);
@@ -60,11 +62,19 @@ const SemanticSearch = () => {
     fetchResults(query);
   };
 
+  const handleFollowUpSubmit = () => {
+    const q = followUpQuery.trim();
+    if (!q) return;
+    setSearchQuery(q);
+    setFollowUpQuery('');
+    fetchResults(q);
+  };
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-teal-50 via-white to-cyan-50">
       <Header />
 
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main className={`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 ${searchQuery ? 'pb-24' : ''}`}>
         <SearchSection
           searchQuery={searchQuery}
           onSearchChange={handleSearchChange}
@@ -82,6 +92,13 @@ const SemanticSearch = () => {
           <SearchResults results={results} searchMode="guidelines" loading={loading} />
         )}
       </main>
+      {searchQuery && !loading && (
+        <FollowUpSearchBar
+          query={followUpQuery}
+          onQueryChange={setFollowUpQuery}
+          onSubmit={handleFollowUpSubmit}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- tweak modals to always use a white background
- expose a fixed follow‑up search bar
- wire follow‑up search bar into semantic search page

## Testing
- `npm install`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a46207f0832980bf62f33f96fdab