### PR TITLE
Add manual search submit handler

### DIFF
--- a/components/SearchSection.tsx
+++ b/components/SearchSection.tsx
@@ -1,12 +1,15 @@
-import { Search, Filter } from 'lucide-react';
+import { Filter, Search } from 'lucide-react';
+
+import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Card } from '@/components/ui/Card';
+
 import { SearchFilters } from './SearchFilters';
 
 interface SearchSectionProps {
   searchQuery: string;
   onSearchChange: (query: string) => void;
+  onSearchSubmit: () => void;
   showFilters: boolean;
   onFilterToggle: () => void;
   filters: {
@@ -22,6 +25,7 @@ interface SearchSectionProps {
 export function SearchSection({
   searchQuery,
   onSearchChange,
+  onSearchSubmit,
   showFilters,
   onFilterToggle,
   filters,
@@ -31,29 +35,40 @@ export function SearchSection({
     onSearchChange(e.target.value);
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      onSearchSubmit();
+    }
+  };
+
   return (
     <div className="w-full max-w-4xl mx-auto mb-8">
       <Card className="p-8 bg-white shadow-lg border border-gray-200">
         {/* Search Bar */}
         <div className="mb-6">
-          <div className="relative">
-            <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
-            <Input
-              type="text"
-              placeholder="Search clinical guidelines..."
-              value={searchQuery}
-              onChange={handleSearchChange}
-              className="pl-12 pr-4 py-4 w-full text-lg border-gray-300 rounded-lg focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-            />
+          <div className="flex items-center">
+            <div className="relative flex-grow mr-2">
+              <Search className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 w-5 h-5" />
+              <Input
+                type="text"
+                placeholder="Search clinical guidelines..."
+                value={searchQuery}
+                onChange={handleSearchChange}
+                onKeyDown={handleKeyDown}
+                className="pl-12 pr-4 py-4 w-full text-lg border-gray-300 rounded-lg focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
+              />
+            </div>
+            <Button onClick={onSearchSubmit} className="flex items-center">
+              <Search className="w-4 h-4 mr-2" />
+              Search
+            </Button>
           </div>
         </div>
 
         {/* Filter Toggle */}
         <div className="flex justify-center">
-          <Button
-            variant="outline"
-            onClick={onFilterToggle}
-          >
+          <Button variant="outline" onClick={onFilterToggle}>
             <Filter className="w-4 h-4 mr-2" />
             {showFilters ? 'Hide Filters' : 'Show Filters'}
           </Button>

--- a/pages/semantic-search.tsx
+++ b/pages/semantic-search.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { useState } from 'react';
-import { Header } from '@/components/Header';
-import { SearchSection } from '@/components/SearchSection';
-import { SearchResults } from '@/components/SearchResults';
+
 import { AISummary } from '@/components/AISummary';
-import { PopularSearches } from '@/components/PopularSearches';
 import { FollowUpSearchBar } from '@/components/FollowUpSearchBar';
+import { Header } from '@/components/Header';
+import { PopularSearches } from '@/components/PopularSearches';
+import { SearchResults } from '@/components/SearchResults';
+import { SearchSection } from '@/components/SearchSection';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:8000';
 
@@ -49,8 +50,12 @@ const SemanticSearch = () => {
 
   const handleSearchChange = (query: string) => {
     setSearchQuery(query);
-    if (query.trim().length >= 3) {
-      fetchResults(query.trim());
+  };
+
+  const handleSearchSubmit = () => {
+    const q = searchQuery.trim();
+    if (q.length >= 3) {
+      fetchResults(q);
     } else {
       setResults([]);
       setSummary('');
@@ -74,22 +79,35 @@ const SemanticSearch = () => {
     <div className="min-h-screen bg-gradient-to-br from-teal-50 via-white to-cyan-50">
       <Header />
 
-      <main className={`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 ${searchQuery ? 'pb-24' : ''}`}>
+      <main
+        className={`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 ${
+          searchQuery ? 'pb-24' : ''
+        }`}
+      >
         <SearchSection
           searchQuery={searchQuery}
           onSearchChange={handleSearchChange}
+          onSearchSubmit={handleSearchSubmit}
           showFilters={showFilters}
           onFilterToggle={() => setShowFilters(!showFilters)}
           filters={filters}
           onFiltersChange={setFilters}
         />
 
-        <AISummary searchQuery={searchQuery} summary={summary} loading={loading} />
+        <AISummary
+          searchQuery={searchQuery}
+          summary={summary}
+          loading={loading}
+        />
 
         {!searchQuery ? (
           <PopularSearches onSearchSelect={handlePopularSearchSelect} />
         ) : (
-          <SearchResults results={results} searchMode="guidelines" loading={loading} />
+          <SearchResults
+            results={results}
+            searchMode="guidelines"
+            loading={loading}
+          />
         )}
       </main>
       {searchQuery && !loading && (


### PR DESCRIPTION
## Summary
- add an `onSearchSubmit` prop to `SearchSection`
- include a Search button and call submit on Enter
- trigger search only on manual submit in semantic search page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840aff324288329807603e62eb9ab05