### PR TITLE
Add NEXT_PUBLIC_API_BASE env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ IMPUTER_PATH=models/breach_imputer.pkl
 EMBED_MODEL=text-embedding-ada-002
 CHAT_MODEL=gpt-4o-mini
 SEARCH_LIMIT=6
+
+# Base URL for the Python API
+NEXT_PUBLIC_API_BASE=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -45,11 +45,12 @@ npm i
 
 **3. Provide API Keys**
 
-Copy `.env.example` to `.env` and populate the values for the Python backend.  
-Create a `.env.local` file in the root of the repo with your OpenAI API Key for the Next.js frontend:
+Copy `.env.example` to `.env` and populate the values for the Python backend.
+Create a `.env.local` file in the root of the repo with your OpenAI API Key and API base URL for the Next.js frontend:
 
 ```bash
 OPENAI_API_KEY=YOUR_KEY
+NEXT_PUBLIC_API_BASE=http://localhost:8000
 ```
 
 > You can set `OPENAI_API_HOST` where access to the official OpenAI host is restricted or unavailable, allowing users to configure an alternative host for their specific needs.


### PR DESCRIPTION
## Summary
- add `NEXT_PUBLIC_API_BASE` to `.env.example`
- document how to set it in the setup steps

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6840b22eea8c8329b4aae8dd80fe1e40