### PR TITLE
Update profile modal layout and options

### DIFF
--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -41,8 +41,8 @@ export function ProfileModal({ isOpen, onClose }: ProfileModalProps) {
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-2xl bg-white">
+    <Dialog open={isOpen} onOpenChange={onClose} className="max-w-2xl">
+      <DialogContent className="bg-white">
         <DialogHeader>
           <DialogTitle className="flex items-center space-x-2">
             <User className="w-5 h-5 text-primary" />
@@ -98,18 +98,28 @@ export function ProfileModal({ isOpen, onClose }: ProfileModalProps) {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
+                  <SelectItem value="Anesthesiology">Anesthesiology</SelectItem>
+                  <SelectItem value="Cardiology">Cardiology</SelectItem>
+                  <SelectItem value="Dermatology">Dermatology</SelectItem>
                   <SelectItem value="Emergency Medicine">
                     Emergency Medicine
                   </SelectItem>
+                  <SelectItem value="Family Medicine">Family Medicine</SelectItem>
+                  <SelectItem value="Gastroenterology">Gastroenterology</SelectItem>
+                  <SelectItem value="General Surgery">General Surgery</SelectItem>
                   <SelectItem value="Internal Medicine">
                     Internal Medicine
                   </SelectItem>
-                  <SelectItem value="Cardiology">Cardiology</SelectItem>
-                  <SelectItem value="Surgery">Surgery</SelectItem>
-                  <SelectItem value="Pediatrics">Pediatrics</SelectItem>
                   <SelectItem value="Intensive Care">Intensive Care</SelectItem>
                   <SelectItem value="Neurology">Neurology</SelectItem>
+                  <SelectItem value="Obstetrics and Gynecology">
+                    Obstetrics and Gynecology
+                  </SelectItem>
                   <SelectItem value="Oncology">Oncology</SelectItem>
+                  <SelectItem value="Orthopedics">Orthopedics</SelectItem>
+                  <SelectItem value="Pediatrics">Pediatrics</SelectItem>
+                  <SelectItem value="Psychiatry">Psychiatry</SelectItem>
+                  <SelectItem value="Radiology">Radiology</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/components/ui/Dialog.tsx
+++ b/components/ui/Dialog.tsx
@@ -1,14 +1,16 @@
 // components/ui/Dialog.tsx
 import React from 'react';
+import { cn } from '@/lib/utils';
 
 // --- Dialog Root ---
 interface DialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   children: React.ReactNode;
+  className?: string;
 }
 
-const Dialog: React.FC<DialogProps> = ({ open, onOpenChange, children }) => {
+const Dialog: React.FC<DialogProps> = ({ open, onOpenChange, children, className }) => {
   // Basic modal logic: render if open. onOpenChange would typically be
   // connected to close buttons or overlay clicks in a real implementation.
   // This mock version relies on the parent controlling the 'open' prop.
@@ -20,7 +22,11 @@ const Dialog: React.FC<DialogProps> = ({ open, onOpenChange, children }) => {
     // Basic overlay and centering structure
     <div className="fixed inset-0 z-50 bg-black/60 flex items-center justify-center p-4">
       {/* Dialog container - basic styling */}
-      <div className="bg-card rounded-lg shadow-lg w-full max-w-md" role="dialog" aria-modal="true">
+      <div
+        className={cn('bg-card rounded-lg shadow-lg w-full max-w-md', className)}
+        role="dialog"
+        aria-modal="true"
+      >
         {children}
       </div>
     </div>

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -12,7 +12,7 @@ export const Label = forwardRef<HTMLLabelElement, LabelProps>(
     return (
       <label
         ref={ref}
-        className={cn('text-sm font-medium text-gray-200', className)}
+        className={cn('text-sm font-medium text-gray-700', className)}
         {...props}
       >
         {children}


### PR DESCRIPTION
## Summary
- widen the profile dialog
- show label text in darker gray
- allow setting dialog width via className
- expand list of medical specialties

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ba32eed08329adc3db181708fc3c