### PR TITLE
Fix summary header, login pages and styling

### DIFF
--- a/components/AISummary.tsx
+++ b/components/AISummary.tsx
@@ -16,12 +16,12 @@ import remarkMath from 'remark-math';
 import rehypeMathjax from 'rehype-mathjax';
 
 interface AISummaryProps {
-  searchQuery: string;
+  query: string;
   summary: string;
   loading: boolean;
 }
 
-export function AISummary({ searchQuery, summary, loading }: AISummaryProps) {
+export function AISummary({ query, summary, loading }: AISummaryProps) {
   const [collapsed, setCollapsed] = useState(false);
 
   const toggleCollapsed = () => setCollapsed((prev) => !prev);
@@ -30,7 +30,7 @@ export function AISummary({ searchQuery, summary, loading }: AISummaryProps) {
     navigator.clipboard.writeText(summary);
   };
   // Show default explanation if no search query
-  if (!searchQuery.trim()) {
+  if (!query.trim()) {
     return (
       <Card className="p-6 mb-6 bg-gradient-to-r from-teal-50 to-cyan-50 border border-teal-200">
         <div className="flex items-center space-x-2 mb-4">
@@ -91,7 +91,7 @@ export function AISummary({ searchQuery, summary, loading }: AISummaryProps) {
           <div className="flex items-center space-x-2">
             <Bot className="w-5 h-5 text-teal-600" />
             <h3 className="text-lg font-semibold text-gray-900">
-              AI Summary: Clinical Guidelines for "{searchQuery}"
+              AI Summary: Clinical Guidelines for "{query}"
             </h3>
             <Badge variant="outline" className="bg-teal-100 text-teal-700 border-teal-300">
               AI Generated

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,6 @@
 import { User, Shield } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import Link from 'next/link';
 import { useState } from 'react';
 import { ProfileModal } from './ProfileModal';
 import { PrivacyPolicyModal } from './PrivacyPolicyModal';
@@ -28,6 +29,13 @@ export function Header() {
 
             {/* Actions */}
             <div className="flex items-center space-x-3">
+              <Link
+                href="/login"
+                className="px-3 py-1.5 text-sm rounded-md bg-teal-600 text-white hover:bg-teal-700"
+              >
+                Sign Up / Login
+              </Link>
+
               <Button
                 variant="ghost"
                 size="sm"

--- a/components/SearchSection.tsx
+++ b/components/SearchSection.tsx
@@ -64,7 +64,7 @@ export function SearchSection({
                 value={searchQuery}
                 onChange={handleSearchChange}
                 onKeyDown={handleKeyDown}
-                className="pl-12 pr-4 py-4 w-full text-lg border-gray-300 rounded-lg focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
+                className="pl-12 pr-4 py-3 w-full text-base border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
               />
             </div>
             <Button onClick={onSearchSubmit} className="flex items-center">

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import Link from 'next/link';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+export default function LoginPage() {
+  const [form, setForm] = useState({ email: '', password: '' });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // Placeholder action
+    alert('Logged in!');
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-teal-50 via-white to-cyan-50 px-4">
+      <div className="w-full max-w-md bg-white rounded-lg shadow-md p-6 space-y-6">
+        <h1 className="text-2xl font-semibold text-gray-900 text-center">Welcome to Metrix</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <Input
+            type="email"
+            name="email"
+            placeholder="Email"
+            required
+            value={form.email}
+            onChange={handleChange}
+          />
+          <Input
+            type="password"
+            name="password"
+            placeholder="Password"
+            required
+            value={form.password}
+            onChange={handleChange}
+          />
+          <Button type="submit" className="w-full">
+            Login
+          </Button>
+        </form>
+        <p className="text-center text-sm text-gray-600">
+          New to Metrix?{' '}
+          <Link href="/signup" className="text-teal-600 hover:underline">
+            Create an account
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/pages/semantic-search.tsx
+++ b/pages/semantic-search.tsx
@@ -12,6 +12,7 @@ const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:8000';
 
 const SemanticSearch = () => {
   const [searchQuery, setSearchQuery] = useState('');
+  const [submittedQuery, setSubmittedQuery] = useState('');
   const [showFilters, setShowFilters] = useState(false);
   const [loading, setLoading] = useState(false);
   const [filters, setFilters] = useState({
@@ -53,15 +54,18 @@ const SemanticSearch = () => {
   const handleSearchSubmit = () => {
     const q = searchQuery.trim();
     if (q.length >= 3) {
+      setSubmittedQuery(q);
       fetchResults(q);
     } else {
       setResults([]);
       setSummary('');
+      setSubmittedQuery('');
     }
   };
 
   const handlePopularSearchSelect = (query: string) => {
     setSearchQuery(query);
+    setSubmittedQuery(query);
     fetchResults(query);
   };
 
@@ -72,7 +76,7 @@ const SemanticSearch = () => {
 
       <main
         className={`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 ${
-          searchQuery ? 'pb-24' : ''
+          submittedQuery ? 'pb-24' : ''
         }`}
       >
         <SearchSection
@@ -86,12 +90,12 @@ const SemanticSearch = () => {
         />
 
         <AISummary
-          searchQuery={searchQuery}
+          query={submittedQuery}
           summary={summary}
           loading={loading}
         />
 
-        {!searchQuery ? (
+        {!submittedQuery ? (
           <PopularSearches onSearchSelect={handlePopularSearchSelect} />
         ) : (
           <SearchResults

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import Link from 'next/link';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+export default function SignupPage() {
+  const [form, setForm] = useState({ name: '', email: '', password: '' });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    alert('Account created!');
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-teal-50 via-white to-cyan-50 px-4">
+      <div className="w-full max-w-md bg-white rounded-lg shadow-md p-6 space-y-6">
+        <h1 className="text-2xl font-semibold text-gray-900 text-center">Create your Metrix account</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <Input
+            type="text"
+            name="name"
+            placeholder="Full name"
+            required
+            value={form.name}
+            onChange={handleChange}
+          />
+          <Input
+            type="email"
+            name="email"
+            placeholder="Email"
+            required
+            value={form.email}
+            onChange={handleChange}
+          />
+          <Input
+            type="password"
+            name="password"
+            placeholder="Password"
+            required
+            value={form.password}
+            onChange={handleChange}
+          />
+          <Button type="submit" className="w-full">
+            Sign Up
+          </Button>
+        </form>
+        <p className="text-center text-sm text-gray-600">
+          Already have an account?{' '}
+          <Link href="/login" className="text-teal-600 hover:underline">
+            Log in
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- keep AI summary header tied to last submitted query
- style search input
- add sign-up/login button in header
- create simple login and signup pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840c1b933488329974f9d093b5beeb4