### PR TITLE
Add OAuth placeholders to login and signup pages

### DIFF
--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,7 +1,14 @@
+import {
+  IconBrandApple,
+  IconBrandGoogle,
+  IconBrandMicrosoft,
+} from '@tabler/icons-react';
 import { useState } from 'react';
+
 import Link from 'next/link';
-import { Input } from '@/components/ui/input';
+
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 
 export default function LoginPage() {
   const [form, setForm] = useState({ email: '', password: '' });
@@ -19,7 +26,45 @@ export default function LoginPage() {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-teal-50 via-white to-cyan-50 px-4">
       <div className="w-full max-w-md bg-white rounded-lg shadow-md p-6 space-y-6">
-        <h1 className="text-2xl font-semibold text-gray-900 text-center">Welcome to Metrix</h1>
+        <h1 className="text-2xl font-semibold text-gray-900 text-center">
+          Welcome to Metrix
+        </h1>
+        <div className="space-y-3">
+          <Button
+            variant="outline"
+            className="w-full flex items-center justify-center space-x-2"
+          >
+            <IconBrandGoogle className="w-5 h-5" />
+            <span>Continue with Google</span>
+          </Button>
+          <Button
+            variant="outline"
+            className="w-full flex items-center justify-center space-x-2"
+          >
+            <IconBrandMicrosoft className="w-5 h-5" />
+            <span>Continue with Microsoft</span>
+          </Button>
+          <Button
+            variant="outline"
+            className="w-full flex items-center justify-center space-x-2"
+          >
+            <IconBrandApple className="w-5 h-5" />
+            <span>Continue with Apple</span>
+          </Button>
+        </div>
+        <div className="relative my-4">
+          <div
+            className="absolute inset-0 flex items-center"
+            aria-hidden="true"
+          >
+            <div className="w-full border-t border-gray-300" />
+          </div>
+          <div className="relative flex justify-center text-sm">
+            <span className="bg-white px-2 text-gray-500">
+              or sign in with your email
+            </span>
+          </div>
+        </div>
         <form onSubmit={handleSubmit} className="space-y-4">
           <Input
             type="email"
@@ -41,6 +86,9 @@ export default function LoginPage() {
             Login
           </Button>
         </form>
+        <p className="text-xs text-gray-500 text-center">
+          Sign in with Google, Microsoft, Apple or your email via Supabase.
+        </p>
         <p className="text-center text-sm text-gray-600">
           New to Metrix?{' '}
           <Link href="/signup" className="text-teal-600 hover:underline">

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -1,7 +1,14 @@
+import {
+  IconBrandApple,
+  IconBrandGoogle,
+  IconBrandMicrosoft,
+} from '@tabler/icons-react';
 import { useState } from 'react';
+
 import Link from 'next/link';
-import { Input } from '@/components/ui/input';
+
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 
 export default function SignupPage() {
   const [form, setForm] = useState({ name: '', email: '', password: '' });
@@ -18,7 +25,45 @@ export default function SignupPage() {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-teal-50 via-white to-cyan-50 px-4">
       <div className="w-full max-w-md bg-white rounded-lg shadow-md p-6 space-y-6">
-        <h1 className="text-2xl font-semibold text-gray-900 text-center">Create your Metrix account</h1>
+        <h1 className="text-2xl font-semibold text-gray-900 text-center">
+          Create your Metrix account
+        </h1>
+        <div className="space-y-3">
+          <Button
+            variant="outline"
+            className="w-full flex items-center justify-center space-x-2"
+          >
+            <IconBrandGoogle className="w-5 h-5" />
+            <span>Sign up with Google</span>
+          </Button>
+          <Button
+            variant="outline"
+            className="w-full flex items-center justify-center space-x-2"
+          >
+            <IconBrandMicrosoft className="w-5 h-5" />
+            <span>Sign up with Microsoft</span>
+          </Button>
+          <Button
+            variant="outline"
+            className="w-full flex items-center justify-center space-x-2"
+          >
+            <IconBrandApple className="w-5 h-5" />
+            <span>Sign up with Apple</span>
+          </Button>
+        </div>
+        <div className="relative my-4">
+          <div
+            className="absolute inset-0 flex items-center"
+            aria-hidden="true"
+          >
+            <div className="w-full border-t border-gray-300" />
+          </div>
+          <div className="relative flex justify-center text-sm">
+            <span className="bg-white px-2 text-gray-500">
+              or sign up with your email
+            </span>
+          </div>
+        </div>
         <form onSubmit={handleSubmit} className="space-y-4">
           <Input
             type="text"
@@ -48,6 +93,9 @@ export default function SignupPage() {
             Sign Up
           </Button>
         </form>
+        <p className="text-xs text-gray-500 text-center">
+          Sign up with Google, Microsoft, Apple or your email via Supabase.
+        </p>
         <p className="text-center text-sm text-gray-600">
           Already have an account?{' '}
           <Link href="/login" className="text-teal-600 hover:underline">


### PR DESCRIPTION
## Summary
- enhance login page with Google/Microsoft/Apple buttons
- enhance signup page with OAuth buttons

## Testing
- `npm test`
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6840c6c2d0ac83298cd4a752536854a0