### PR TITLE
Update search UI layout

### DIFF
--- a/components/DocumentCard.tsx
+++ b/components/DocumentCard.tsx
@@ -1,0 +1,81 @@
+import { FileText, Calendar, ExternalLink } from 'lucide-react';
+import { Card, CardContent, CardHeader } from '@/components/ui/Card';
+import { Badge } from '@/components/ui/Badge';
+import { Button } from '@/components/ui/button';
+
+interface DocumentCardProps {
+  title: string;
+  summary: string;
+  publishDate?: string;
+  specialty?: string;
+  type?: string;
+  relevanceScore?: number;
+  url?: string;
+}
+
+const DocumentCard = ({
+  title,
+  summary,
+  publishDate,
+  specialty,
+  type,
+  relevanceScore,
+  url,
+}: DocumentCardProps) => {
+  return (
+    <Card className="hover:shadow-md transition-shadow duration-200 border border-gray-200">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1">
+            <div className="flex items-center gap-2 mb-2">
+              <FileText className="h-4 w-4 text-teal-600" />
+              {type && (
+                <Badge variant="secondary" className="text-xs">
+                  {type}
+                </Badge>
+              )}
+              {specialty && (
+                <Badge variant="outline" className="text-xs">
+                  {specialty}
+                </Badge>
+              )}
+            </div>
+            <h3 className="font-semibold text-gray-900 leading-tight hover:text-teal-600 cursor-pointer">
+              {title}
+            </h3>
+          </div>
+          {relevanceScore !== undefined && (
+            <div className="text-right text-sm text-gray-500">
+              <div className="font-medium text-green-600">
+                {Math.round(relevanceScore * 100)}% match
+              </div>
+            </div>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <p className="text-gray-700 text-sm leading-relaxed mb-4">{summary}</p>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-4 text-xs text-gray-500">
+            {publishDate && (
+              <div className="flex items-center gap-1">
+                <Calendar className="h-3 w-3" />
+                {publishDate}
+              </div>
+            )}
+          </div>
+          {url && (
+            <Button variant="outline" size="sm" className="text-xs" asChild>
+              <a href={url} target="_blank" rel="noopener noreferrer">
+                <ExternalLink className="h-3 w-3 mr-1" />
+                View Full
+              </a>
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default DocumentCard;

--- a/components/FiltersSidebar.tsx
+++ b/components/FiltersSidebar.tsx
@@ -1,0 +1,40 @@
+import { X } from 'lucide-react';
+import { Dialog, DialogContent } from '@/components/ui/Dialog';
+import { Button } from '@/components/ui/button';
+import { SearchFilters } from './SearchFilters';
+
+interface FiltersSidebarProps {
+  isOpen: boolean;
+  onClose: () => void;
+  filters: {
+    sources: string[];
+    specialties: string[];
+    trust: string;
+    dateRange: string;
+    evidenceLevel: string;
+  };
+  onFiltersChange: (filters: any) => void;
+}
+
+const FiltersSidebar = ({ isOpen, onClose, filters, onFiltersChange }: FiltersSidebarProps) => {
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="bg-white h-full overflow-y-auto max-w-sm">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold">Filters</h2>
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+        <SearchFilters
+          isOpen={true}
+          searchMode="guidelines"
+          filters={filters}
+          onFiltersChange={onFiltersChange}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default FiltersSidebar;

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,11 +1,11 @@
-import { User, Shield } from 'lucide-react';
+import { Search, User, LogIn, UserPlus, Shield } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 import { useState } from 'react';
 import { ProfileModal } from './ProfileModal';
 import { PrivacyPolicyModal } from './PrivacyPolicyModal';
 
-export function Header() {
+const Header = () => {
   const [isProfileOpen, setIsProfileOpen] = useState(false);
   const [isPrivacyOpen, setIsPrivacyOpen] = useState(false);
 
@@ -13,45 +13,43 @@ export function Header() {
     <>
       <header className="bg-white border-b border-gray-200 shadow-sm">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-16">
-            {/* Logo */}
-            <div className="flex items-center space-x-4">
-              <div className="flex items-center space-x-2">
-                <div className="w-8 h-8 bg-gradient-to-br from-teal-500 to-teal-600 rounded-lg flex items-center justify-center">
-                  <Shield className="w-5 h-5 text-white" />
-                </div>
-                <div>
-                  <h1 className="text-xl font-bold text-gray-900">Metrix</h1>
-                  <p className="text-xs text-gray-500">Clinical Guidelines Platform</p>
-                </div>
-              </div>
+          <div className="flex justify-between items-center h-16">
+            <div className="flex items-center">
+              <Search className="h-8 w-8 text-teal-600 mr-3" />
+              <h1 className="text-2xl font-bold text-gray-900">Metrix</h1>
             </div>
 
-            {/* Actions */}
-            <div className="flex items-center space-x-3">
+            <nav className="hidden md:flex space-x-8">
               <Link
-                href="/login"
-                className="px-3 py-1.5 text-sm rounded-md bg-teal-600 text-white hover:bg-teal-700"
+                href="#"
+                className="text-gray-500 hover:text-gray-900 px-3 py-2 text-sm font-medium transition-colors"
               >
-                Sign Up / Login
+                About
               </Link>
-
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => setIsProfileOpen(true)}
-              >
-                <User className="w-4 h-4 mr-2" />
-                Profile
-              </Button>
-
-              <Button
-                variant="ghost"
-                size="sm"
+              <button
+                className="text-gray-500 hover:text-gray-900 px-3 py-2 text-sm font-medium transition-colors"
                 onClick={() => setIsPrivacyOpen(true)}
-                className="text-xs"
               >
-                Privacy Policy
+                <Shield className="h-4 w-4 inline mr-1" />
+                Privacy
+              </button>
+            </nav>
+
+            <div className="flex items-center space-x-4">
+              <Link href="/login" className="hidden sm:flex">
+                <Button variant="ghost" size="sm">
+                  <LogIn className="h-4 w-4 mr-2" />
+                  Sign In
+                </Button>
+              </Link>
+              <Link href="/login" className="hidden sm:flex">
+                <Button size="sm" className="bg-teal-600 hover:bg-teal-700">
+                  <UserPlus className="h-4 w-4 mr-2" />
+                  Sign Up
+                </Button>
+              </Link>
+              <Button variant="outline" size="sm" className="p-2" onClick={() => setIsProfileOpen(true)}>
+                <User className="h-4 w-4" />
               </Button>
             </div>
           </div>

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -1,0 +1,50 @@
+import { Search, Filter } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useState } from 'react';
+
+interface SearchBarProps {
+  onSearch: (query: string) => void;
+  onToggleFilters: () => void;
+}
+
+const SearchBar = ({ onSearch, onToggleFilters }: SearchBarProps) => {
+  const [query, setQuery] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSearch(query);
+  };
+
+  return (
+    <div className="w-full max-w-4xl mx-auto">
+      <form onSubmit={handleSubmit} className="relative">
+        <div className="flex gap-2">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-5 w-5" />
+            <Input
+              type="text"
+              placeholder="Search guidelines, protocols, and medical documents..."
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="pl-10 pr-4 py-3 text-lg border-2 border-gray-200 focus:border-teal-500 rounded-lg"
+            />
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onToggleFilters}
+            className="px-4 py-3 border-2 border-gray-200 hover:border-teal-500"
+          >
+            <Filter className="h-5 w-5" />
+          </Button>
+          <Button type="submit" className="px-8 py-3 bg-teal-600 hover:bg-teal-700 text-lg font-medium">
+            Search
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default SearchBar;

--- a/components/SearchResults.tsx
+++ b/components/SearchResults.tsx
@@ -1,4 +1,4 @@
-import { Card } from '@/components/ui/Card';
+import DocumentCard from '@/components/DocumentCard';
 
 interface SearchResultsProps {
   results: any[];
@@ -18,25 +18,16 @@ export function SearchResults({ results, loading }: SearchResultsProps) {
   return (
     <div className="space-y-4">
       {results.map((r, idx) => (
-        <Card key={idx} className="p-4 border border-gray-200">
-          <h3 className="font-semibold text-gray-900 mb-1">
-            {r.document_title || r.title}
-          </h3>
-          {r.heading && <p className="text-sm text-gray-600 mb-1">{r.heading}</p>}
-          {r.page_number && (
-            <p className="text-xs text-gray-500">Page {r.page_number}</p>
-          )}
-          {r.url && (
-            <a
-              href={r.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-sm text-teal-600 underline"
-            >
-              View Source
-            </a>
-          )}
-        </Card>
+        <DocumentCard
+          key={idx}
+          title={r.document_title || r.title}
+          summary={r.heading || ''}
+          publishDate={r.publish_date}
+          specialty={r.specialty}
+          type={r.type}
+          relevanceScore={r.score}
+          url={r.url}
+        />
       ))}
     </div>
   );

--- a/pages/semantic-search.tsx
+++ b/pages/semantic-search.tsx
@@ -3,17 +3,18 @@
 import { useState } from 'react';
 
 import { AISummary } from '@/components/AISummary';
-import { Header } from '@/components/Header';
+import Header from '@/components/Header';
 import { PopularSearches } from '@/components/PopularSearches';
 import { SearchResults } from '@/components/SearchResults';
-import { SearchSection } from '@/components/SearchSection';
+import SearchBar from '@/components/SearchBar';
+import FiltersSidebar from '@/components/FiltersSidebar';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:8000';
 
 const SemanticSearch = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [submittedQuery, setSubmittedQuery] = useState('');
-  const [showFilters, setShowFilters] = useState(false);
+  const [filtersOpen, setFiltersOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [filters, setFilters] = useState({
     sources: [],
@@ -47,12 +48,9 @@ const SemanticSearch = () => {
     }
   };
 
-  const handleSearchChange = (query: string) => {
+  const handleSearch = (query: string) => {
     setSearchQuery(query);
-  };
-
-  const handleSearchSubmit = () => {
-    const q = searchQuery.trim();
+    const q = query.trim();
     if (q.length >= 3) {
       setSubmittedQuery(q);
       fetchResults(q);
@@ -69,41 +67,45 @@ const SemanticSearch = () => {
     fetchResults(query);
   };
 
+  const toggleFilters = () => {
+    setFiltersOpen(!filtersOpen);
+  };
+
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-teal-50 via-white to-cyan-50">
+    <div className="min-h-screen bg-gray-50">
       <Header />
 
-      <main
-        className={`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 ${
-          submittedQuery ? 'pb-24' : ''
-        }`}
-      >
-        <SearchSection
-          searchQuery={searchQuery}
-          onSearchChange={handleSearchChange}
-          onSearchSubmit={handleSearchSubmit}
-          showFilters={showFilters}
-          onFilterToggle={() => setShowFilters(!showFilters)}
+      <main className="flex">
+        <div className="flex-1">
+          <div className="bg-gradient-to-br from-teal-600 via-teal-700 to-teal-800 text-white py-16 px-4">
+            <div className="max-w-4xl mx-auto text-center">
+              <h1 className="text-4xl md:text-5xl font-bold mb-6">Find Medical Guidelines & Protocols</h1>
+              <p className="text-xl md:text-2xl text-teal-100 mb-8 font-light">
+                AI-powered search across thousands of clinical guidelines and research documents
+              </p>
+              <div className="mt-8">
+                <SearchBar onSearch={handleSearch} onToggleFilters={toggleFilters} />
+              </div>
+            </div>
+          </div>
+
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+            <AISummary query={submittedQuery} summary={summary} loading={loading} />
+            {!submittedQuery ? (
+              <PopularSearches onSearchSelect={handlePopularSearchSelect} />
+            ) : (
+              <SearchResults results={results} searchMode="guidelines" loading={loading} />
+            )}
+          </div>
+        </div>
+
+        <FiltersSidebar
+          isOpen={filtersOpen}
+          onClose={() => setFiltersOpen(false)}
           filters={filters}
           onFiltersChange={setFilters}
         />
-
-        <AISummary
-          query={submittedQuery}
-          summary={summary}
-          loading={loading}
-        />
-
-        {!submittedQuery ? (
-          <PopularSearches onSearchSelect={handlePopularSearchSelect} />
-        ) : (
-          <SearchResults
-            results={results}
-            searchMode="guidelines"
-            loading={loading}
-          />
-        )}
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- modernize Header layout with action buttons
- add SearchBar, FiltersSidebar, and DocumentCard components
- update SearchResults to use DocumentCard
- redesign semantic-search page to new layout

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841670c9ea883298f3b009212f11298