### PR TITLE
Remove Microsoft sign-in options

### DIFF
--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,7 +1,6 @@
 import {
   IconBrandApple,
   IconBrandGoogle,
-  IconBrandWindows,
 } from '@tabler/icons-react';
 import { useState } from 'react';
 
@@ -36,13 +35,6 @@ export default function LoginPage() {
           >
             <IconBrandGoogle className="w-5 h-5" />
             <span>Continue with Google</span>
-          </Button>
-          <Button
-            variant="outline"
-            className="w-full flex items-center justify-center space-x-2"
-          >
-            <IconBrandWindows className="w-5 h-5" />
-            <span>Continue with Microsoft</span>
           </Button>
           <Button
             variant="outline"
@@ -87,7 +79,7 @@ export default function LoginPage() {
           </Button>
         </form>
         <p className="text-xs text-gray-500 text-center">
-          Sign in with Google, Microsoft, Apple or your email via Supabase.
+          Sign in with Google, Apple or your email via Supabase.
         </p>
         <p className="text-center text-sm text-gray-600">
           New to Metrix?{' '}

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -1,7 +1,6 @@
 import {
   IconBrandApple,
   IconBrandGoogle,
-  IconBrandMicrosoft,
 } from '@tabler/icons-react';
 import { useState } from 'react';
 
@@ -35,13 +34,6 @@ export default function SignupPage() {
           >
             <IconBrandGoogle className="w-5 h-5" />
             <span>Sign up with Google</span>
-          </Button>
-          <Button
-            variant="outline"
-            className="w-full flex items-center justify-center space-x-2"
-          >
-            <IconBrandMicrosoft className="w-5 h-5" />
-            <span>Sign up with Microsoft</span>
           </Button>
           <Button
             variant="outline"
@@ -94,7 +86,7 @@ export default function SignupPage() {
           </Button>
         </form>
         <p className="text-xs text-gray-500 text-center">
-          Sign up with Google, Microsoft, Apple or your email via Supabase.
+          Sign up with Google, Apple or your email via Supabase.
         </p>
         <p className="text-center text-sm text-gray-600">
           Already have an account?{' '}


### PR DESCRIPTION
## Summary
- remove IconBrandMicrosoft and IconBrandWindows usage
- drop Microsoft sign-up/sign-in buttons
- adjust copy text referencing Microsoft

## Testing
- `npm test` *(fails: vitest not installed)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416c371e348329ba6b270b517c3e73