### PR TITLE
Integrate Supabase authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,7 @@ SEARCH_LIMIT=6
 
 # Base URL for the Python API
 NEXT_PUBLIC_API_BASE=http://localhost:8000
+
+# Supabase credentials
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,66 +1,60 @@
-import { Search, User, LogIn, UserPlus, Shield } from 'lucide-react';
+import { Search, LogIn, UserPlus, Shield } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useAuth } from '@/contexts/AuthContext';
+import UserMenu from './UserMenu';
 import { useState } from 'react';
-import { ProfileModal } from './ProfileModal';
 import { PrivacyPolicyModal } from './PrivacyPolicyModal';
 
 const Header = () => {
-  const [isProfileOpen, setIsProfileOpen] = useState(false);
+  const { user, loading } = useAuth();
+  const router = useRouter();
   const [isPrivacyOpen, setIsPrivacyOpen] = useState(false);
 
   return (
-    <>
-      <header className="bg-white border-b border-gray-200 shadow-sm">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <div className="flex items-center">
-              <Search className="h-8 w-8 text-teal-600 mr-3" />
-              <h1 className="text-2xl font-bold text-gray-900">Metrix</h1>
-            </div>
-
-            <nav className="hidden md:flex space-x-8">
-              <Link
-                href="#"
-                className="text-gray-500 hover:text-gray-900 px-3 py-2 text-sm font-medium transition-colors"
-              >
-                About
-              </Link>
-              <button
-                className="text-gray-500 hover:text-gray-900 px-3 py-2 text-sm font-medium transition-colors"
-                onClick={() => setIsPrivacyOpen(true)}
-              >
-                <Shield className="h-4 w-4 inline mr-1" />
-                Privacy
-              </button>
-            </nav>
-
-            <div className="flex items-center space-x-4">
-              <Link href="/login" className="hidden sm:flex">
-                <Button variant="ghost" size="sm">
-                  <LogIn className="h-4 w-4 mr-2" />
-                  Sign In
-                </Button>
-              </Link>
-              <Link href="/login" className="hidden sm:flex">
-                <Button size="sm" className="bg-teal-600 hover:bg-teal-700">
-                  <UserPlus className="h-4 w-4 mr-2" />
-                  Sign Up
-                </Button>
-              </Link>
-              <Button variant="outline" size="sm" className="p-2" onClick={() => setIsProfileOpen(true)}>
-                <User className="h-4 w-4" />
-              </Button>
-            </div>
+    <header className="bg-white border-b border-gray-200 shadow-sm">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between items-center h-16">
+          <div className="flex items-center cursor-pointer" onClick={() => router.push('/')}> 
+            <Search className="h-8 w-8 text-teal-600 mr-3" />
+            <h1 className="text-2xl font-bold text-gray-900">Metrix</h1>
+          </div>
+          <nav className="hidden md:flex space-x-8">
+            <Link href="#" className="text-gray-500 hover:text-gray-900 px-3 py-2 text-sm font-medium transition-colors">
+              About
+            </Link>
+            <button className="text-gray-500 hover:text-gray-900 px-3 py-2 text-sm font-medium transition-colors" onClick={() => setIsPrivacyOpen(true)}>
+              <Shield className="h-4 w-4 inline mr-1" />
+              Privacy
+            </button>
+          </nav>
+          <div className="flex items-center space-x-4">
+            {!loading && (
+              user ? (
+                <UserMenu />
+              ) : (
+                <>
+                  <Button variant="ghost" size="sm" className="hidden sm:flex" onClick={() => router.push('/login')}>
+                    <LogIn className="h-4 w-4 mr-2" />
+                    Sign In
+                  </Button>
+                  <Button size="sm" className="hidden sm:flex bg-teal-600 hover:bg-teal-700" onClick={() => router.push('/signup')}>
+                    <UserPlus className="h-4 w-4 mr-2" />
+                    Sign Up
+                  </Button>
+                  <Button variant="outline" size="sm" className="p-2 sm:hidden" onClick={() => router.push('/login')}>
+                    <LogIn className="h-4 w-4" />
+                  </Button>
+                </>
+              )
+            )}
           </div>
         </div>
-      </header>
-
-      <ProfileModal isOpen={isProfileOpen} onClose={() => setIsProfileOpen(false)} />
-
+      </div>
       <PrivacyPolicyModal isOpen={isPrivacyOpen} onClose={() => setIsPrivacyOpen(false)} />
-    </>
+    </header>
   );
-}
+};
 
 export default Header;

--- a/components/UserMenu.tsx
+++ b/components/UserMenu.tsx
@@ -1,0 +1,70 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/Dialog';
+import { useAuth } from '@/contexts/AuthContext';
+import { useState } from 'react';
+import { User, LogOut, Settings } from 'lucide-react';
+
+export default function UserMenu() {
+  const { user, signOut } = useAuth();
+  const [open, setOpen] = useState(false);
+
+  if (!user) return null;
+
+  const getInitials = (name: string) =>
+    name
+      .split(' ')
+      .map((w) => w[0])
+      .join('')
+      .toUpperCase()
+      .slice(0, 2);
+
+  const displayName = (user.user_metadata as any)?.full_name || user.email;
+
+  const handleSignOut = async () => {
+    const { error } = await signOut();
+    if (error) alert('Failed to sign out');
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="ghost" className="p-1 h-auto">
+          <Avatar className="h-8 w-8">
+            <AvatarImage src={(user.user_metadata as any)?.avatar_url} />
+            <AvatarFallback className="bg-teal-600 text-white text-sm">
+              {displayName ? getInitials(displayName) : <User className="h-4 w-4" />}
+            </AvatarFallback>
+          </Avatar>
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Avatar className="h-10 w-10">
+              <AvatarImage src={(user.user_metadata as any)?.avatar_url} />
+              <AvatarFallback className="bg-teal-600 text-white">
+                {displayName ? getInitials(displayName) : <User className="h-5 w-5" />}
+              </AvatarFallback>
+            </Avatar>
+            <div>
+              <p className="text-lg font-semibold">{displayName}</p>
+              <p className="text-sm text-gray-500">{user.email}</p>
+            </div>
+          </DialogTitle>
+          <DialogDescription>Manage your account settings and preferences.</DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-2 mt-4">
+          <Button variant="outline" className="justify-start">
+            <Settings className="h-4 w-4 mr-2" />
+            Account Settings
+          </Button>
+          <Button variant="outline" className="justify-start text-red-600 hover:text-red-700 hover:bg-red-50" onClick={handleSignOut}>
+            <LogOut className="h-4 w-4 mr-2" />
+            Sign Out
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+export function Avatar({ className, children }: { className?: string; children: React.ReactNode }) {
+  return <div className={`relative flex shrink-0 overflow-hidden rounded-full ${className ?? ''}`}>{children}</div>;
+}
+
+export function AvatarImage({ src, alt }: { src?: string; alt?: string }) {
+  return <img className="aspect-square h-full w-full" src={src} alt={alt} />;
+}
+
+export function AvatarFallback({ className, children }: { className?: string; children: React.ReactNode }) {
+  return <span className={`flex h-full w-full items-center justify-center rounded-full ${className ?? ''}`}>{children}</span>;
+}

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -1,0 +1,78 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import type { Session, User } from '@supabase/supabase-js';
+import { supabase } from '@/integrations/supabase/client';
+
+interface AuthContextType {
+  user: User | null;
+  session: Session | null;
+  loading: boolean;
+  signUp: (email: string, password: string, fullName?: string) => Promise<{ error: any }>;
+  signIn: (email: string, password: string) => Promise<{ error: any }>;
+  signInWithGoogle: () => Promise<{ error: any }>;
+  signOut: () => Promise<{ error: any }>;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+};
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [session, setSession] = useState<Session | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session);
+      setUser(session?.user ?? null);
+      setLoading(false);
+    });
+
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setSession(session);
+      setUser(session?.user ?? null);
+      setLoading(false);
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  const signUp = async (email: string, password: string, fullName?: string) => {
+    const redirectUrl = `${window.location.origin}/`;
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: {
+        emailRedirectTo: redirectUrl,
+        data: fullName ? { full_name: fullName } : undefined,
+      },
+    });
+    return { error };
+  };
+
+  const signIn = async (email: string, password: string) => {
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    return { error };
+  };
+
+  const signInWithGoogle = async () => {
+    const redirectUrl = `${window.location.origin}/`;
+    const { error } = await supabase.auth.signInWithOAuth({ provider: 'google', options: { redirectTo: redirectUrl } });
+    return { error };
+  };
+
+  const signOut = async () => {
+    const { error } = await supabase.auth.signOut();
+    return { error };
+  };
+
+  const value: AuthContextType = { user, session, loading, signUp, signIn, signInWithGoogle, signOut };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};

--- a/integrations/supabase/client.ts
+++ b/integrations/supabase/client.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@heroicons/react": "^2.2.0",
         "@mui/icons-material": "^6.4.8",
         "@mui/material": "^6.4.8",
+        "@supabase/supabase-js": "^2.49.10",
         "@tabler/icons-react": "^2.9.0",
         "@typeform/embed-react": "^2.21.0",
         "@types/async-busboy": "^1.1.1",
@@ -1693,6 +1694,102 @@
       "integrity": "sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==",
       "dev": true
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.69.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.69.1.tgz",
+      "integrity": "sha512-FILtt5WjCNzmReeRLq5wRs3iShwmnWgBvxHfqapC/VoljJl+W8hDAyFmf1NVw3zH+ZjZ05AKxiKxVeb0HNWRMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.4.tgz",
+      "integrity": "sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@supabase/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.11.10",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.10.tgz",
+      "integrity": "sha512-SJKVa7EejnuyfImrbzx+HaD9i6T784khuw1zP+MBD7BmJYChegGxYigPzkKX8CK8nGuDntmeSD3fvriaH0EGZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
+      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.49.10",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.49.10.tgz",
+      "integrity": "sha512-IRPcIdncuhD2m1eZ2Fkg0S1fq9SXlHfmAetBxPN66kVFtTucR8b01xKuVmKqcIJokB17umMf1bmqyS8yboXGsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.69.1",
+        "@supabase/functions-js": "2.4.4",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.19.4",
+        "@supabase/realtime-js": "2.11.10",
+        "@supabase/storage-js": "2.7.1"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
@@ -1948,6 +2045,12 @@
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "license": "MIT"
     },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
@@ -2022,6 +2125,15 @@
       "version": "0.0.46",
       "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.46.tgz",
       "integrity": "sha512-ki0OmbjSdAEfvmy5AYWFpMkRsPW+6h4ibQ4tzk8SJsS9dkrrD3B/U1eVvdNNWxAzntjq6o2sjSia6UBCoPH+Yg=="
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.55.0",
@@ -10404,9 +10516,10 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -11524,6 +11637,91 @@
       "integrity": "sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==",
       "dev": true
     },
+    "@supabase/auth-js": {
+      "version": "2.69.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.69.1.tgz",
+      "integrity": "sha512-FILtt5WjCNzmReeRLq5wRs3iShwmnWgBvxHfqapC/VoljJl+W8hDAyFmf1NVw3zH+ZjZ05AKxiKxVeb0HNWRMQ==",
+      "requires": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "@supabase/functions-js": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.4.tgz",
+      "integrity": "sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==",
+      "requires": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@supabase/postgrest-js": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "requires": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "@supabase/realtime-js": {
+      "version": "2.11.10",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.10.tgz",
+      "integrity": "sha512-SJKVa7EejnuyfImrbzx+HaD9i6T784khuw1zP+MBD7BmJYChegGxYigPzkKX8CK8nGuDntmeSD3fvriaH0EGZA==",
+      "requires": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "@supabase/storage-js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
+      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "requires": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "@supabase/supabase-js": {
+      "version": "2.49.10",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.49.10.tgz",
+      "integrity": "sha512-IRPcIdncuhD2m1eZ2Fkg0S1fq9SXlHfmAetBxPN66kVFtTucR8b01xKuVmKqcIJokB17umMf1bmqyS8yboXGsw==",
+      "requires": {
+        "@supabase/auth-js": "2.69.1",
+        "@supabase/functions-js": "2.4.4",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.19.4",
+        "@supabase/realtime-js": "2.11.10",
+        "@supabase/storage-js": "2.7.1"
+      }
+    },
     "@swc/helpers": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
@@ -11745,6 +11943,11 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
     },
+    "@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A=="
+    },
     "@types/prop-types": {
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
@@ -11815,6 +12018,14 @@
       "version": "0.0.46",
       "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.46.tgz",
       "integrity": "sha512-ki0OmbjSdAEfvmy5AYWFpMkRsPW+6h4ibQ4tzk8SJsS9dkrrD3B/U1eVvdNNWxAzntjq6o2sjSia6UBCoPH+Yg=="
+    },
+    "@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@typescript-eslint/parser": {
       "version": "5.55.0",
@@ -17697,9 +17908,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
       "requires": {}
     },
     "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@heroicons/react": "^2.2.0",
     "@mui/icons-material": "^6.4.8",
     "@mui/material": "^6.4.8",
+    "@supabase/supabase-js": "^2.49.10",
     "@tabler/icons-react": "^2.9.0",
     "@typeform/embed-react": "^2.21.0",
     "@types/async-busboy": "^1.1.1",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,16 +1,17 @@
-// /pages/_app.tsx
 import type { AppProps } from 'next/app';
 import { Inter } from 'next/font/google';
 import { appWithTranslation } from 'next-i18next';
-
 import '@/styles/globals.css';
+import { AuthProvider } from '@/contexts/AuthContext';
 
 const inter = Inter({ subsets: ['latin'] });
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <div className={inter.className}>
-      <Component {...pageProps} />
+      <AuthProvider>
+        <Component {...pageProps} />
+      </AuthProvider>
     </div>
   );
 }

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,86 +1,68 @@
-import {
-  IconBrandApple,
-  IconBrandGoogle,
-} from '@tabler/icons-react';
-import { useState } from 'react';
-
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { IconBrandGoogle } from '@tabler/icons-react';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { useAuth } from '@/contexts/AuthContext';
 
 export default function LoginPage() {
   const [form, setForm] = useState({ email: '', password: '' });
+  const [loading, setLoading] = useState(false);
+  const { signIn, signInWithGoogle, user } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (user) router.replace('/');
+  }, [user, router]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value });
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // Placeholder action
-    alert('Logged in!');
+    setLoading(true);
+    const { error } = await signIn(form.email, form.password);
+    setLoading(false);
+    if (!error) router.replace('/');
+    else alert(error.message);
+  };
+
+  const handleGoogle = async () => {
+    setLoading(true);
+    const { error } = await signInWithGoogle();
+    if (error) alert(error.message);
+    setLoading(false);
   };
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-teal-50 via-white to-cyan-50 px-4">
       <div className="w-full max-w-md bg-white rounded-lg shadow-md p-6 space-y-6">
-        <h1 className="text-2xl font-semibold text-gray-900 text-center">
-          Welcome to Metrix
-        </h1>
+        <h1 className="text-2xl font-semibold text-gray-900 text-center">Welcome to Metrix</h1>
         <div className="space-y-3">
-          <Button
-            variant="outline"
-            className="w-full flex items-center justify-center space-x-2"
-          >
+          <Button variant="outline" onClick={handleGoogle} disabled={loading} className="w-full flex items-center justify-center space-x-2">
             <IconBrandGoogle className="w-5 h-5" />
             <span>Continue with Google</span>
           </Button>
-          <Button
-            variant="outline"
-            className="w-full flex items-center justify-center space-x-2"
-          >
-            <IconBrandApple className="w-5 h-5" />
-            <span>Continue with Apple</span>
-          </Button>
         </div>
         <div className="relative my-4">
-          <div
-            className="absolute inset-0 flex items-center"
-            aria-hidden="true"
-          >
+          <div className="absolute inset-0 flex items-center" aria-hidden="true">
             <div className="w-full border-t border-gray-300" />
           </div>
           <div className="relative flex justify-center text-sm">
-            <span className="bg-white px-2 text-gray-500">
-              or sign in with your email
-            </span>
+            <span className="bg-white px-2 text-gray-500">or sign in with your email</span>
           </div>
         </div>
         <form onSubmit={handleSubmit} className="space-y-4">
-          <Input
-            type="email"
-            name="email"
-            placeholder="Email"
-            required
-            value={form.email}
-            onChange={handleChange}
-          />
-          <Input
-            type="password"
-            name="password"
-            placeholder="Password"
-            required
-            value={form.password}
-            onChange={handleChange}
-          />
-          <Button type="submit" className="w-full">
-            Login
+          <Input type="email" name="email" placeholder="Email" required value={form.email} onChange={handleChange} />
+          <Input type="password" name="password" placeholder="Password" required value={form.password} onChange={handleChange} />
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading ? 'Please wait...' : 'Login'}
           </Button>
         </form>
-        <p className="text-xs text-gray-500 text-center">
-          Sign in with Google, Apple or your email via Supabase.
-        </p>
+        <p className="text-xs text-gray-500 text-center">Sign in with Google or your email via Supabase.</p>
         <p className="text-center text-sm text-gray-600">
           New to Metrix?{' '}
           <Link href="/signup" className="text-teal-600 hover:underline">

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -1,93 +1,73 @@
-import {
-  IconBrandApple,
-  IconBrandGoogle,
-} from '@tabler/icons-react';
-import { useState } from 'react';
-
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { IconBrandGoogle } from '@tabler/icons-react';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { useAuth } from '@/contexts/AuthContext';
 
 export default function SignupPage() {
   const [form, setForm] = useState({ name: '', email: '', password: '' });
+  const [loading, setLoading] = useState(false);
+  const { signUp, signInWithGoogle, user } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (user) router.replace('/');
+  }, [user, router]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value });
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    alert('Account created!');
+    setLoading(true);
+    const { error } = await signUp(form.email, form.password, form.name);
+    setLoading(false);
+    if (!error) {
+      alert('Please check your email to confirm your account.');
+      router.replace('/');
+    } else {
+      alert(error.message);
+    }
+  };
+
+  const handleGoogle = async () => {
+    setLoading(true);
+    const { error } = await signInWithGoogle();
+    if (error) alert(error.message);
+    setLoading(false);
   };
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-teal-50 via-white to-cyan-50 px-4">
       <div className="w-full max-w-md bg-white rounded-lg shadow-md p-6 space-y-6">
-        <h1 className="text-2xl font-semibold text-gray-900 text-center">
-          Create your Metrix account
-        </h1>
+        <h1 className="text-2xl font-semibold text-gray-900 text-center">Create your Metrix account</h1>
         <div className="space-y-3">
-          <Button
-            variant="outline"
-            className="w-full flex items-center justify-center space-x-2"
-          >
+          <Button variant="outline" onClick={handleGoogle} disabled={loading} className="w-full flex items-center justify-center space-x-2">
             <IconBrandGoogle className="w-5 h-5" />
             <span>Sign up with Google</span>
           </Button>
-          <Button
-            variant="outline"
-            className="w-full flex items-center justify-center space-x-2"
-          >
-            <IconBrandApple className="w-5 h-5" />
-            <span>Sign up with Apple</span>
-          </Button>
         </div>
         <div className="relative my-4">
-          <div
-            className="absolute inset-0 flex items-center"
-            aria-hidden="true"
-          >
+          <div className="absolute inset-0 flex items-center" aria-hidden="true">
             <div className="w-full border-t border-gray-300" />
           </div>
           <div className="relative flex justify-center text-sm">
-            <span className="bg-white px-2 text-gray-500">
-              or sign up with your email
-            </span>
+            <span className="bg-white px-2 text-gray-500">or sign up with your email</span>
           </div>
         </div>
         <form onSubmit={handleSubmit} className="space-y-4">
-          <Input
-            type="text"
-            name="name"
-            placeholder="Full name"
-            required
-            value={form.name}
-            onChange={handleChange}
-          />
-          <Input
-            type="email"
-            name="email"
-            placeholder="Email"
-            required
-            value={form.email}
-            onChange={handleChange}
-          />
-          <Input
-            type="password"
-            name="password"
-            placeholder="Password"
-            required
-            value={form.password}
-            onChange={handleChange}
-          />
-          <Button type="submit" className="w-full">
-            Sign Up
+          <Input type="text" name="name" placeholder="Full name" required value={form.name} onChange={handleChange} />
+          <Input type="email" name="email" placeholder="Email" required value={form.email} onChange={handleChange} />
+          <Input type="password" name="password" placeholder="Password" required value={form.password} onChange={handleChange} />
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading ? 'Please wait...' : 'Sign Up'}
           </Button>
         </form>
-        <p className="text-xs text-gray-500 text-center">
-          Sign up with Google, Apple or your email via Supabase.
-        </p>
+        <p className="text-xs text-gray-500 text-center">Sign up with Google or your email via Supabase.</p>
         <p className="text-center text-sm text-gray-600">
           Already have an account?{' '}
           <Link href="/login" className="text-teal-600 hover:underline">


### PR DESCRIPTION
## Summary
- add Supabase client and context provider
- add login and signup pages using Supabase email/Google auth
- show user menu with sign out in the header
- expose Supabase env variables
- install `@supabase/supabase-js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684172ca19a883299464b6190777ad70