### PR TITLE
Handle missing Supabase env vars

### DIFF
--- a/integrations/supabase/client.ts
+++ b/integrations/supabase/client.ts
@@ -1,6 +1,18 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
+let client: SupabaseClient | null = null;
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const getSupabaseClient = (): SupabaseClient | null => {
+  if (!client) {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+    if (supabaseUrl && supabaseAnonKey) {
+      client = createClient(supabaseUrl, supabaseAnonKey);
+    } else {
+      return null;
+    }
+  }
+
+  return client;
+};


### PR DESCRIPTION
## Summary
- avoid creating Supabase client when env vars are missing
- guard AuthContext logic when Supabase is unavailable

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68417f1f64f08329b4a3fcfa65fe1adb