### PR TITLE
Fix build by adding CardDescription

### DIFF
--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -89,10 +89,29 @@ const CardContent = React.forwardRef<HTMLDivElement, CardContentProps>(
 CardContent.displayName = 'CardContent';
 
 
+// --- Card Description ---
+export interface CardDescriptionProps
+  extends React.HTMLAttributes<HTMLParagraphElement> {
+  className?: string;
+}
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  CardDescriptionProps
+>(({ className, ...props }, ref) => {
+  const baseStyle = 'text-sm text-gray-500';
+  const combinedClassName = `${baseStyle} ${className ?? ''}`;
+
+  return <p ref={ref} className={combinedClassName} {...props} />;
+});
+CardDescription.displayName = 'CardDescription';
+
+
 // Export all related components
 export {
   Card,
   CardHeader,
   CardTitle,
   CardContent,
+  CardDescription,
 };

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -215,7 +215,7 @@ const About = () => {
                 <Mail className="h-5 w-5" />
                 <span className="font-medium">info@metrix-health.com</span>
               </div>
-              <Button variant="secondary" className="bg-white text-gray-900 hover:bg-gray-100">
+              <Button variant="outline" className="bg-white text-gray-900 hover:bg-gray-100">
                 <Mail className="h-4 w-4 mr-2" />
                 Get in Touch
               </Button>


### PR DESCRIPTION
## Summary
- add `CardDescription` component and export it
- update About page to use valid button variant

## Testing
- `npx vitest run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841873d735883299690e826da19388a