### PR TITLE
Replace privacy modal with pages and update header

### DIFF
--- a/components/AISummary.tsx
+++ b/components/AISummary.tsx
@@ -165,8 +165,8 @@ export function AISummary({ query, summary, loading }: AISummaryProps) {
               {summary}
             </ReactMarkdown>
 
-            <Alert className="bg-yellow-50 border-yellow-200">
-              <AlertTriangle className="h-4 w-4 text-yellow-600" />
+            <Alert className="bg-yellow-50 border-yellow-200 flex items-start gap-2">
+              <AlertTriangle className="h-4 w-4 mt-0.5 text-yellow-600" />
               <AlertDescription className="text-yellow-800 text-sm">
                 <strong>Important Disclaimer:</strong> This AI-generated summary
                 is for informational purposes only and may contain errors.

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,58 +1,87 @@
-import { Search, LogIn, UserPlus, Shield } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { FileText, LogIn, Search, Shield, UserPlus } from 'lucide-react';
+
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useAuth } from '@/contexts/AuthContext';
+
+import { Button } from '@/components/ui/button';
+
 import UserMenu from './UserMenu';
-import { useState } from 'react';
-import { PrivacyPolicyModal } from './PrivacyPolicyModal';
+
+import { useAuth } from '@/contexts/AuthContext';
 
 const Header = () => {
   const { user, loading } = useAuth();
   const router = useRouter();
-  const [isPrivacyOpen, setIsPrivacyOpen] = useState(false);
 
   return (
     <header className="bg-white border-b border-gray-200 shadow-sm">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
-          <div className="flex items-center cursor-pointer" onClick={() => router.push('/')}> 
+          <div
+            className="flex items-center cursor-pointer"
+            onClick={() => router.push('/')}
+          >
             <Search className="h-8 w-8 text-teal-600 mr-3" />
             <h1 className="text-2xl font-bold text-gray-900">Metrix</h1>
           </div>
-          <nav className="hidden md:flex space-x-8">
-            <Link href="/about" className="text-gray-500 hover:text-gray-900 px-3 py-2 text-sm font-medium transition-colors">
+          <nav className="hidden md:flex items-center space-x-6">
+            <Link
+              href="/about"
+              className="text-gray-500 hover:text-gray-900 px-3 py-2 text-sm font-medium transition-colors"
+            >
               About
             </Link>
-            <button className="text-gray-500 hover:text-gray-900 px-3 py-2 text-sm font-medium transition-colors" onClick={() => setIsPrivacyOpen(true)}>
-              <Shield className="h-4 w-4 inline mr-1" />
+            <Link
+              href="/privacy"
+              className="flex items-center text-gray-500 hover:text-gray-900 px-3 py-2 text-sm font-medium transition-colors"
+            >
+              <Shield className="h-4 w-4 mr-1" />
               Privacy
-            </button>
+            </Link>
+            <Link
+              href="/terms-of-service"
+              className="flex items-center text-gray-500 hover:text-gray-900 px-3 py-2 text-sm font-medium transition-colors"
+            >
+              <FileText className="h-4 w-4 mr-1" />
+              Terms
+            </Link>
           </nav>
           <div className="flex items-center space-x-4">
-            {!loading && (
-              user ? (
+            {!loading &&
+              (user ? (
                 <UserMenu />
               ) : (
                 <>
-                  <Button variant="ghost" size="sm" className="hidden sm:flex" onClick={() => router.push('/login')}>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="hidden sm:flex"
+                    onClick={() => router.push('/login')}
+                  >
                     <LogIn className="h-4 w-4 mr-2" />
                     Sign In
                   </Button>
-                  <Button size="sm" className="hidden sm:flex bg-teal-600 hover:bg-teal-700" onClick={() => router.push('/signup')}>
+                  <Button
+                    size="sm"
+                    className="hidden sm:flex bg-teal-600 hover:bg-teal-700"
+                    onClick={() => router.push('/signup')}
+                  >
                     <UserPlus className="h-4 w-4 mr-2" />
                     Sign Up
                   </Button>
-                  <Button variant="outline" size="sm" className="p-2 sm:hidden" onClick={() => router.push('/login')}>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="p-2 sm:hidden"
+                    onClick={() => router.push('/login')}
+                  >
                     <LogIn className="h-4 w-4" />
                   </Button>
                 </>
-              )
-            )}
+              ))}
           </div>
         </div>
       </div>
-      <PrivacyPolicyModal isOpen={isPrivacyOpen} onClose={() => setIsPrivacyOpen(false)} />
     </header>
   );
 };

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -1,26 +1,12 @@
 import { Shield } from 'lucide-react';
+import React from 'react';
 import ReactMarkdown from 'react-markdown';
 
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/Dialog';
-import { Button } from '@/components/ui/button';
-import { ScrollArea } from '@/components/ui/scroll-area';
+import Header from '@/components/Header';
 
 import remarkGfm from 'remark-gfm';
 
-interface PrivacyPolicyModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-}
-
-export function PrivacyPolicyModal({
-  isOpen,
-  onClose,
-}: PrivacyPolicyModalProps) {
+export default function PrivacyPage() {
   const policyMarkdown = `### Metrix Health Privacy Policy
 
 *Effective Date: 4 June 2025*
@@ -161,31 +147,22 @@ For any privacy‑related questions or concerns, contact our Data Protection Off
 ---
 
 **Last Reviewed:** 4 June 2025`;
+
   return (
-    <Dialog open={isOpen} onOpenChange={onClose} className="max-w-[56rem]">
-      <DialogContent className="max-w-5xl max-h-[80vh] bg-white">
-        <DialogHeader>
-          <DialogTitle className="flex items-center space-x-2">
-            <Shield className="w-5 h-5 text-primary" />
-            <span>Privacy Policy</span>
-          </DialogTitle>
-        </DialogHeader>
-
-        <ScrollArea className="h-[60vh] pr-4">
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
-            className="prose prose-sm max-w-none text-gray-700"
-          >
-            {policyMarkdown}
-          </ReactMarkdown>
-        </ScrollArea>
-
-        <div className="flex justify-end pt-4 border-t">
-          <Button onClick={onClose} className="bg-primary hover:bg-primary-600">
-            Close
-          </Button>
-        </div>
-      </DialogContent>
-    </Dialog>
+    <div className="min-h-screen bg-gray-50">
+      <Header />
+      <main className="max-w-4xl mx-auto p-4 pt-8">
+        <h1 className="text-2xl font-bold mb-6 flex items-center gap-2">
+          <Shield className="w-5 h-5 text-primary" />
+          Privacy Policy
+        </h1>
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          className="prose prose-sm max-w-none text-gray-700"
+        >
+          {policyMarkdown}
+        </ReactMarkdown>
+      </main>
+    </div>
   );
 }

--- a/pages/terms-of-service.tsx
+++ b/pages/terms-of-service.tsx
@@ -1,0 +1,67 @@
+import { FileText } from 'lucide-react';
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+
+import Header from '@/components/Header';
+
+import remarkGfm from 'remark-gfm';
+
+export default function TermsOfServicePage() {
+  const termsMarkdown = `### Terms of Service
+
+*Effective Date: 4 June 2025*
+
+---
+
+By accessing or using the Metrix platform (the **"Service"**), you agree to be bound by these Terms of Service (the **"Terms"**). If you do not agree to these Terms, do not use the Service.
+
+#### 1. Use of the Service
+
+You may use the Service only for lawful purposes and in accordance with these Terms. You are responsible for all content that you submit or actions you take through the Service.
+
+#### 2. Intellectual Property
+
+All content and software associated with the Service are the property of Metrix Health Ltd or its licensors. You may not reproduce, distribute, or create derivative works without our express permission.
+
+#### 3. Termination
+
+We may suspend or terminate your access to the Service at any time if you violate these Terms or engage in fraudulent or illegal activities.
+
+#### 4. Disclaimer of Warranties
+
+The Service is provided on an "as is" and "as available" basis without warranties of any kind. We do not guarantee that the Service will be uninterrupted or error-free.
+
+#### 5. Limitation of Liability
+
+To the fullest extent permitted by law, Metrix Health Ltd shall not be liable for any indirect, incidental, or consequential damages arising out of or relating to your use of the Service.
+
+#### 6. Governing Law
+
+These Terms are governed by the laws of England and Wales. Any disputes will be resolved exclusively in the courts of England and Wales.
+
+#### 7. Contact Us
+
+If you have any questions about these Terms, please contact **[support@metrixhealth.ai](mailto:support@metrixhealth.ai)**.
+
+---
+
+**Last Updated:** 4 June 2025`;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Header />
+      <main className="max-w-4xl mx-auto p-4 pt-8">
+        <h1 className="text-2xl font-bold mb-6 flex items-center gap-2">
+          <FileText className="w-5 h-5 text-primary" />
+          Terms of Service
+        </h1>
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          className="prose prose-sm max-w-none text-gray-700"
+        >
+          {termsMarkdown}
+        </ReactMarkdown>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/privacy` page and move policy text there
- create `/terms-of-service` page
- clean up header navigation and link to new pages
- align AI disclaimer icon with text

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6841b3aeda908329b9360c10d3c175c3